### PR TITLE
Updating pipeline: pl_copy_data

### DIFF
--- a/pipeline/pl_copy_data.json
+++ b/pipeline/pl_copy_data.json
@@ -4,7 +4,7 @@
 		"activities": [
 			{
 				"name": "copy_data",
-				"description": "added description for test fix for test\n",
+				"description": "paraxel",
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {


### PR DESCRIPTION
This pull request includes a minor change to the `pipeline/pl_copy_data.json` file. The change updates the description of the `copy_data` activity.

* [`pipeline/pl_copy_data.json`](diffhunk://#diff-c2dd1fcf09d4ad78146ad18ed469a2f9c3b161e525db3b7e61903ffc3fe68241L7-R7): Changed the description of the `copy_data` activity from "added description for test fix for test\n" to "paraxel".